### PR TITLE
feat(auth): add forgot password and remember me features

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { Header } from '@/components/layout/Header';
 import { Home } from '@/pages/Home';
 import { Transactions } from '@/pages/Transactions';
 import { Login } from '@/pages/Login';
+import { ForgotPassword } from '@/pages/ForgotPassword';
 
 function AppContent() {
   const [currentPage, setCurrentPage] = useState<'home' | 'transactions'>('home');
@@ -51,6 +52,7 @@ function AppContent() {
 
 function App() {
   const { isAuthenticated, isLoading } = useAuth();
+  const [authPage, setAuthPage] = useState<'login' | 'forgot-password'>('login');
 
   // Loading state
   if (isLoading) {
@@ -66,7 +68,10 @@ function App() {
 
   // Auth guard
   if (!isAuthenticated) {
-    return <Login />;
+    if (authPage === 'forgot-password') {
+      return <ForgotPassword onBackToLogin={() => setAuthPage('login')} />;
+    }
+    return <Login onForgotPassword={() => setAuthPage('forgot-password')} />;
   }
 
   // Authenticated - show dashboard

--- a/src/components/ui/Checkbox.tsx
+++ b/src/components/ui/Checkbox.tsx
@@ -1,0 +1,31 @@
+import { InputHTMLAttributes, forwardRef } from 'react';
+
+interface CheckboxProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'type'> {
+  label?: string;
+}
+
+export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
+  ({ label, className = '', id, ...props }, ref) => {
+    const checkboxId = id || `checkbox-${Math.random().toString(36).substr(2, 9)}`;
+
+    return (
+      <div className="flex items-center">
+        <input
+          ref={ref}
+          type="checkbox"
+          id={checkboxId}
+          className={`h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded ${className}`}
+          {...props}
+        />
+        {label && (
+          <label htmlFor={checkboxId} className="ml-2 block text-sm text-gray-700 cursor-pointer">
+            {label}
+          </label>
+        )}
+      </div>
+    );
+  }
+);
+
+Checkbox.displayName = 'Checkbox';
+

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -22,8 +22,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     // Verificar credenciais
     const userData = await authService.verifyCredentials(credentials);
 
+    // Calcular duração da sessão: 365 dias se "Lembrar-me" marcado, senão 7 dias padrão
+    const durationDays = credentials.rememberMe ? 365 : 7;
+
     // Criar sessão
-    const session = sessionService.createSession(userData);
+    const session = sessionService.createSession(userData, durationDays);
 
     // Atualizar estado
     setUser(session.user);

--- a/src/pages/ForgotPassword.tsx
+++ b/src/pages/ForgotPassword.tsx
@@ -1,0 +1,192 @@
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { authService } from '@/services/auth.service';
+import { Card } from '@/components/ui/Card';
+import { Input } from '@/components/ui/Input';
+import { Button } from '@/components/ui/Button';
+
+interface ForgotPasswordForm {
+  email: string;
+}
+
+interface ForgotPasswordProps {
+  onBackToLogin: () => void;
+}
+
+export function ForgotPassword({ onBackToLogin }: ForgotPasswordProps) {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [emailValidated, setEmailValidated] = useState(false);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<ForgotPasswordForm>();
+
+  const onSubmit = async (data: ForgotPasswordForm) => {
+    setIsLoading(true);
+    setError(null);
+    setEmailValidated(false);
+
+    try {
+      // Validar email
+      const isValid = authService.validateEmailForPasswordReset(data.email);
+      
+      if (isValid) {
+        setEmailValidated(true);
+      } else {
+        // Por segurança, mostrar erro genérico mesmo se email não corresponder
+        setError('Se o email informado estiver cadastrado, você receberá instruções.');
+        // Mas ainda mostrar as instruções para não frustrar o usuário
+        setEmailValidated(true);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Erro ao validar email');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 flex items-center justify-center p-4">
+      <div className="w-full max-w-md">
+        {/* Header */}
+        <div className="text-center mb-8">
+          <h1 className="text-4xl font-bold text-gray-900 mb-2">
+            Esqueci minha senha
+          </h1>
+          <p className="text-gray-600">
+            Recupere o acesso ao seu dashboard
+          </p>
+        </div>
+
+        {/* Card */}
+        <Card>
+          <div className="p-8">
+            {!emailValidated ? (
+              <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+                {/* Email */}
+                <div>
+                  <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-2">
+                    Email
+                  </label>
+                  <Input
+                    id="email"
+                    type="email"
+                    placeholder="seu@email.com"
+                    {...register('email', {
+                      required: 'Email é obrigatório',
+                      pattern: {
+                        value: /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i,
+                        message: 'Email inválido',
+                      },
+                    })}
+                    disabled={isLoading}
+                  />
+                  {errors.email && (
+                    <p className="mt-1 text-sm text-red-600">
+                      {errors.email.message}
+                    </p>
+                  )}
+                </div>
+
+                {/* Erro geral */}
+                {error && (
+                  <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded">
+                    {error}
+                  </div>
+                )}
+
+                {/* Botão Submit */}
+                <Button
+                  type="submit"
+                  disabled={isLoading}
+                  className="w-full"
+                >
+                  {isLoading ? 'Validando...' : 'Continuar'}
+                </Button>
+
+                {/* Botão Voltar */}
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={onBackToLogin}
+                  className="w-full"
+                  disabled={isLoading}
+                >
+                  Voltar para login
+                </Button>
+              </form>
+            ) : (
+              <div className="space-y-6">
+                {/* Instruções */}
+                <div className="space-y-4">
+                  <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
+                    <h3 className="font-semibold text-blue-900 mb-2">
+                      Instruções para redefinir sua senha
+                    </h3>
+                    <p className="text-sm text-blue-800 mb-4">
+                      Para redefinir sua senha, você precisa gerar um novo hash SHA-256 e atualizar o arquivo de configuração.
+                    </p>
+                  </div>
+
+                  <div className="space-y-3">
+                    <div>
+                      <h4 className="font-medium text-gray-900 mb-2">Passo 1: Gerar novo hash</h4>
+                      <p className="text-sm text-gray-600 mb-2">
+                        Execute o comando no terminal:
+                      </p>
+                      <code className="block bg-gray-100 p-3 rounded text-sm font-mono text-gray-800">
+                        npm run generate-hash
+                      </code>
+                      <p className="text-xs text-gray-500 mt-2">
+                        Digite sua nova senha quando solicitado. O script gerará um hash SHA-256.
+                      </p>
+                    </div>
+
+                    <div>
+                      <h4 className="font-medium text-gray-900 mb-2">Passo 2: Atualizar configuração</h4>
+                      <p className="text-sm text-gray-600 mb-2">
+                        Abra o arquivo <code className="bg-gray-100 px-1 rounded">.env.local</code> na raiz do projeto e atualize:
+                      </p>
+                      <code className="block bg-gray-100 p-3 rounded text-sm font-mono text-gray-800">
+                        VITE_AUTH_PASSWORD_HASH=seu_novo_hash_aqui
+                      </code>
+                    </div>
+
+                    <div>
+                      <h4 className="font-medium text-gray-900 mb-2">Passo 3: Reiniciar aplicação</h4>
+                      <p className="text-sm text-gray-600">
+                        Se a aplicação estiver rodando, pare e inicie novamente para carregar as novas variáveis de ambiente.
+                      </p>
+                    </div>
+
+                    <div className="pt-2 border-t border-gray-200">
+                      <p className="text-xs text-gray-500">
+                        Para mais detalhes, consulte a documentação em{' '}
+                        <code className="bg-gray-100 px-1 rounded">docs/config-auth/SETUP_AUTH.md</code>
+                        .
+                      </p>
+                    </div>
+                  </div>
+                </div>
+
+                {/* Botão Voltar */}
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={onBackToLogin}
+                  className="w-full"
+                >
+                  Voltar para login
+                </Button>
+              </div>
+            )}
+          </div>
+        </Card>
+      </div>
+    </div>
+  );
+}
+

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -4,9 +4,14 @@ import { useAuth } from '@/contexts/AuthContext';
 import { Card } from '@/components/ui/Card';
 import { Input } from '@/components/ui/Input';
 import { Button } from '@/components/ui/Button';
+import { Checkbox } from '@/components/ui/Checkbox';
 import type { LoginCredentials } from '@/types/auth.types';
 
-export function Login() {
+interface LoginProps {
+  onForgotPassword?: () => void;
+}
+
+export function Login({ onForgotPassword }: LoginProps) {
   const { login } = useAuth();
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -97,6 +102,16 @@ export function Login() {
                 )}
               </div>
 
+              {/* Lembrar-me */}
+              <div>
+                <Checkbox
+                  id="rememberMe"
+                  label="Lembrar-me"
+                  {...register('rememberMe')}
+                  disabled={isLoading}
+                />
+              </div>
+
               {/* Erro geral */}
               {error && (
                 <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded">
@@ -112,6 +127,20 @@ export function Login() {
               >
                 {isLoading ? 'Entrando...' : 'Entrar'}
               </Button>
+
+              {/* Link Esqueci minha senha */}
+              {onForgotPassword && (
+                <div className="text-center">
+                  <button
+                    type="button"
+                    onClick={onForgotPassword}
+                    disabled={isLoading}
+                    className="text-sm text-blue-600 hover:text-blue-800 underline disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    Esqueci minha senha
+                  </button>
+                </div>
+              )}
             </form>
 
             {/* Info sobre configuração */}

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -48,6 +48,25 @@ export const authService = {
   },
 
   /**
+   * Valida email para reset de senha
+   * @param email Email a ser validado
+   * @returns true se email corresponde ao configurado, false caso contrário
+   * @throws Error genérico se email não corresponder (por segurança, não revela emails válidos)
+   */
+  validateEmailForPasswordReset(email: string): boolean {
+    const validEmail = import.meta.env.VITE_AUTH_EMAIL;
+
+    if (!validEmail) {
+      throw new Error(
+        'Credenciais não configuradas. Configure VITE_AUTH_EMAIL no .env.local'
+      );
+    }
+
+    // Retorna true apenas se email corresponder exatamente
+    return email.toLowerCase().trim() === validEmail.toLowerCase().trim();
+  },
+
+  /**
    * PLACEHOLDER para migração futura
    * Quando houver backend, substituir verifyCredentials() por:
    * 

--- a/src/services/session.service.ts
+++ b/src/services/session.service.ts
@@ -7,12 +7,15 @@ const SESSION_DURATION_DAYS = 7;
 export const sessionService = {
   /**
    * Cria uma nova sessão para o usuário
+   * @param user Dados do usuário
+   * @param durationDays Duração da sessão em dias (padrão: 7 dias)
    */
-  createSession(user: User): SessionData {
+  createSession(user: User, durationDays?: number): SessionData {
+    const days = durationDays ?? SESSION_DURATION_DAYS;
     const session: SessionData = {
       token: generateUUID(),
       user,
-      expiresAt: Date.now() + (SESSION_DURATION_DAYS * 24 * 60 * 60 * 1000),
+      expiresAt: Date.now() + (days * 24 * 60 * 60 * 1000),
     };
 
     localStorage.setItem(SESSION_KEY, JSON.stringify(session));

--- a/src/types/auth.types.ts
+++ b/src/types/auth.types.ts
@@ -7,6 +7,7 @@ export interface User {
 export interface LoginCredentials {
   email: string;
   password: string;
+  rememberMe?: boolean;
 }
 
 export interface SessionData {


### PR DESCRIPTION
## 📝 Descrição

Este PR implementa melhorias no fluxo de autenticação:
- Adiciona **"Remember me"** no login para estender a sessão para **365 dias**
- Adiciona fluxo de **"Forgot password"** com validação de email e instruções para reset manual via `.env.local`
- Introduz componente reutilizável `Checkbox` e adiciona navegação entre Login ↔ ForgotPassword

## 🔄 Tipo de Mudança

- [x] ✨ Nova funcionalidade (feat)
- [ ] 🐛 Correção de bug (fix)
- [ ] 📚 Documentação (docs)
- [ ] 🎨 Estilo/Formatação (style)
- [ ] ♻️ Refatoração (refactor)
- [ ] ⚡ Performance (perf)
- [ ] ✅ Testes (test)
- [ ] 🔧 Configuração/CI/CD (chore)

## ✅ Checklist

- [x] Meu código segue os padrões de estilo do projeto
- [x] Realizei uma auto-revisão do meu código
- [x] Comentei código complexo quando necessário
- [x] Minhas mudanças não geram novos warnings
- [ ] Adicionei testes que provam que minha correção é efetiva ou que minha funcionalidade funciona
- [ ] Testes unitários novos e existentes passam localmente com minhas mudanças
- [x] Executei `npm run lint` e não há erros
- [x] Executei `npm run build` e o build passou sem erros
- [x] Commits seguem o padrão [Conventional Commits](https://www.conventionalcommits.org/)

## 📸 Screenshots (se aplicável)

N/A

## 🔗 Issues Relacionadas

Closes #

## ⚠️ Breaking Changes

Nenhuma.

## 📋 Informações Adicionais

Principais mudanças técnicas:
- `sessionService.createSession(user, durationDays?)` agora suporta duração customizada
- `LoginCredentials` inclui `rememberMe?: boolean`
- `authService.validateEmailForPasswordReset(email)` adicionado para o fluxo de recuperação